### PR TITLE
Mirror of nike-inc cerberus-management-service#175

### DIFF
--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaAuthConnector.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaAuthConnector.java
@@ -44,6 +44,8 @@ public class OktaAuthConnector implements AuthConnector {
 
     private final OktaClientResponseUtils oktaClientResponseUtils;
 
+    private static final ImmutableSet UNSUPPORTED_OKTA_MFA_TYPES = ImmutableSet.of("push", "call", "sms");
+
     @Inject
     public OktaAuthConnector(final OktaApiClientHelper oktaApiClientHelper,
                              final OktaClientResponseUtils oktaClientResponseUtils) {
@@ -77,7 +79,7 @@ public class OktaAuthConnector implements AuthConnector {
                         String type = factor.getFactorType().toLowerCase();
                         String provider = factor.getProvider();
                         return ! (provider.equalsIgnoreCase("okta") &&
-                                ImmutableSet.of("push", "call", "sms").contains(type));
+                                UNSUPPORTED_OKTA_MFA_TYPES.contains(type));
                     }).collect(Collectors.toList());
 
 

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaAuthConnector.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaAuthConnector.java
@@ -80,8 +80,7 @@ public class OktaAuthConnector implements AuthConnector {
                                 ImmutableSet.of("push", "call", "sms").contains(type));
                     }).collect(Collectors.toList());
 
-//            Do we need to move this after the filtering in order to properly set the message to address
-//            that MFA might not work because they need to have Okta Verify or Google Authenticator set up?
+
             oktaClientResponseUtils.validateUserFactors(factors);
 
             factors.forEach(factor -> authData.getDevices().add(new AuthMfaDevice()

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtils.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtils.java
@@ -171,8 +171,7 @@ public class OktaClientResponseUtils {
                     .withApiErrors(new ApiErrorBase(
                             DefaultApiError.MFA_SETUP_REQUIRED.getName(),
                             DefaultApiError.MFA_SETUP_REQUIRED.getErrorCode(),
-                            "MFA is required, but user has not set up any devices in Okta.\n" +
-                                    "Please set up a MFA device in Okta: " + baseUrl,
+                            "MFA is required. Please set up a supported device, either Okta Verify or Google Authenticator. " + baseUrl,
                             DefaultApiError.MFA_SETUP_REQUIRED.getHttpStatusCode()))
                     .withExceptionMessage("MFA is required, but user has not set up any devices in Okta.")
                     .build();

--- a/src/main/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtils.java
+++ b/src/main/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtils.java
@@ -17,6 +17,7 @@
 
 package com.nike.cerberus.auth.connector.okta;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -45,19 +46,35 @@ public class OktaClientResponseUtils {
     public static final String MFA_FACTOR_NOT_SETUP_STATUS = "NOT_SETUP";
 
     private static final ImmutableMap<String, String> MFA_FACTOR_NAMES = ImmutableMap.of(
-            "google", "Google Authenticator",
-            "okta"  , "Okta Verify");
+            "google-token:software:totp",   "Google Authenticator",
+            "okta-token:software:totp",     "Okta Verify TOTP",
+            "okta-push",                    "Okta Verify Push",
+            "okta-call",                    "Okta Voice Call",
+            "okta-sms",                     "Okta Text Message Code");
 
     private final ObjectMapper objectMapper;
 
     private final String baseUrl;
 
     @Inject
-    public OktaClientResponseUtils(final ObjectMapper objectMapper,
-                                   @Named("auth.connector.okta.base_url") final String baseUrl) {
+    public OktaClientResponseUtils(@Named("auth.connector.okta.base_url") final String baseUrl) {
 
-        this.objectMapper = objectMapper;
+        this.objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         this.baseUrl = baseUrl;
+    }
+
+    /**
+     * Combine the provider and factor type to create factor key
+     * @param factor
+     * @return factor key
+     */
+    protected String getFactorKey(Factor factor) {
+
+        final String factorProvider = factor.getProvider().toLowerCase();
+        final String factorType = factor.getFactorType().toLowerCase();
+
+        return factorProvider + "-" + factorType;
     }
 
     /**
@@ -69,12 +86,13 @@ public class OktaClientResponseUtils {
 
         Preconditions.checkArgument(factor != null, "factor cannot be null.");
 
-        final String factorProvider = factor.getProvider().toLowerCase();
-        if (MFA_FACTOR_NAMES.containsKey(factorProvider)) {
-            return MFA_FACTOR_NAMES.get(factorProvider);
+        final String factorKey = getFactorKey(factor);
+
+        if (MFA_FACTOR_NAMES.containsKey(factorKey)) {
+            return MFA_FACTOR_NAMES.get(factorKey);
         }
 
-        return WordUtils.capitalizeFully(factorProvider);
+        return WordUtils.capitalizeFully(factorKey);
     }
 
     /**

--- a/src/test/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtilsTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtilsTest.java
@@ -17,7 +17,10 @@
 
 package com.nike.cerberus.auth.connector.okta;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.nike.backstopper.exception.ApiException;
@@ -28,9 +31,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static groovy.util.GroovyTestCase.assertEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -58,7 +64,20 @@ public class OktaClientResponseUtilsTest {
         baseUrl = "base url";
 
         // create test object
-        this.oktaClientResponseUtils = new OktaClientResponseUtils(objectMapper, baseUrl);
+        this.oktaClientResponseUtils = new OktaClientResponseUtils(baseUrl);
+    }
+
+    @Test
+    public void getFactorKey() {
+
+        Factor factor = new Factor();
+        factor.setFactorType("push");
+        factor.setProvider("OKTA");
+
+        String expected = "okta-push";
+        String actual = oktaClientResponseUtils.getFactorKey(factor);
+
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -74,15 +93,64 @@ public class OktaClientResponseUtilsTest {
     }
 
     @Test
-    public void getDeviceNameGoogle() {
+    public void getDeviceNameGoogleTotp() {
 
-        String provider = "GOOGLE";
-        Factor factor = mock(Factor.class);
-        when(factor.getProvider()).thenReturn(provider);
+        Factor factor = new Factor();
+        factor.setFactorType("token:software:totp");
+        factor.setProvider("GOOGLE");
 
         String result = this.oktaClientResponseUtils.getDeviceName(factor);
 
         assertEquals("Google Authenticator", result);
+    }
+
+    @Test
+    public void getDeviceNameOktaTotp() {
+
+        Factor factor = new Factor();
+        factor.setFactorType("totp");
+        factor.setProvider("OKTA");
+
+        String result = this.oktaClientResponseUtils.getDeviceName(factor);
+
+        assertEquals("Okta Verify TOTP", result);
+    }
+
+    @Test
+    public void getDeviceNameOktaPush() {
+
+        Factor factor = new Factor();
+        factor.setFactorType("push");
+        factor.setProvider("OKTA");
+
+        String result = this.oktaClientResponseUtils.getDeviceName(factor);
+
+        assertEquals("Okta Verify Push", result);
+
+    }
+
+    @Test
+    public void getDeviceNameOktaCall() {
+
+        Factor factor = new Factor();
+        factor.setFactorType("call");
+        factor.setProvider("OKTA");
+
+        String result = this.oktaClientResponseUtils.getDeviceName(factor);
+
+        assertEquals("Okta Voice Call", result);
+    }
+
+    @Test
+    public void getDeviceNameOktaSms() {
+
+        Factor factor = new Factor();
+        factor.setFactorType("sms");
+        factor.setProvider("OKTA");
+
+        String result = this.oktaClientResponseUtils.getDeviceName(factor);
+
+        assertEquals("Okta Text Message Code", result);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtilsTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/okta/OktaClientResponseUtilsTest.java
@@ -81,18 +81,6 @@ public class OktaClientResponseUtilsTest {
     }
 
     @Test
-    public void getDeviceName() {
-
-        String provider = "provider";
-        Factor factor = mock(Factor.class);
-        when(factor.getProvider()).thenReturn(provider);
-
-        String result = this.oktaClientResponseUtils.getDeviceName(factor);
-
-        assertEquals(StringUtils.capitalize(provider), result);
-    }
-
-    @Test
     public void getDeviceNameGoogleTotp() {
 
         Factor factor = new Factor();
@@ -108,7 +96,7 @@ public class OktaClientResponseUtilsTest {
     public void getDeviceNameOktaTotp() {
 
         Factor factor = new Factor();
-        factor.setFactorType("totp");
+        factor.setFactorType("token:software:totp");
         factor.setProvider("OKTA");
 
         String result = this.oktaClientResponseUtils.getDeviceName(factor);
@@ -234,4 +222,5 @@ public class OktaClientResponseUtilsTest {
 
         this.oktaClientResponseUtils.validateUserFactors(Lists.newArrayList(factor1, factor2));
     }
+
 }

--- a/src/test/java/com/nike/cerberus/auth/connector/okta/OktaMFAAuthConnectorTest.java
+++ b/src/test/java/com/nike/cerberus/auth/connector/okta/OktaMFAAuthConnectorTest.java
@@ -138,7 +138,6 @@ public class OktaMFAAuthConnectorTest {
         assertEquals(email, result.getData().getUsername());
         assertEquals(1, result.getData().getDevices().size());
         assertEquals(deviceId, result.getData().getDevices().get(0).getId());
-        assertEquals(StringUtils.capitalize(provider), result.getData().getDevices().get(0).getName());
     }
 
     @Test(expected = ApiException.class)
@@ -198,7 +197,6 @@ public class OktaMFAAuthConnectorTest {
         assertEquals(email, result.getData().getUsername());
         assertEquals(1, result.getData().getDevices().size());
         assertEquals(deviceId, result.getData().getDevices().get(0).getId());
-        assertEquals(StringUtils.capitalize(provider), result.getData().getDevices().get(0).getName());
     }
 
     @Test


### PR DESCRIPTION
Mirror of nike-inc cerberus-management-service#175
Fixed the mapping for device names. Now when users are asked to use MFA to log in, they will see an accurate dropdown list of each verification method they have. Push, call, and sms notifications are filtered from the list because we do not currently support them.
